### PR TITLE
Fixed project name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure that you have Node.js and npm installed on your machine.
 2. Navigate to the project directory:
 
    ```bash
-   cd calendizer
+   cd popcorned
    ```
 
 3. Install dependencies:


### PR DESCRIPTION
Fixed incorrect project name in the README installation instructions.
The 'cd calendizer' command was mistakenly left in and has been corrected to 'cd popcorned'.
